### PR TITLE
Feature/eav tables

### DIFF
--- a/migrations/2023-04-04-011810_create_jobs/down.sql
+++ b/migrations/2023-04-04-011810_create_jobs/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE jobs;
+DROP TYPE job_status;

--- a/migrations/2023-04-04-011810_create_jobs/up.sql
+++ b/migrations/2023-04-04-011810_create_jobs/up.sql
@@ -1,0 +1,11 @@
+CREATE TYPE job_status AS ENUM ('pending', 'initialized', 'running', 'completed', 'failed', 'dead');
+
+CREATE TABLE jobs (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    status job_status NOT NULL DEFAULT 'pending',
+    worker varchar(255) NOT NULL,
+    payload jsonb,
+
+    created_at timestamp with time zone NOT NULL DEFAULT current_timestamp,
+    updated_at timestamp with time zone NOT NULL DEFAULT current_timestamp
+);

--- a/migrations/2023-04-05-013204_eav/down.sql
+++ b/migrations/2023-04-05-013204_eav/down.sql
@@ -1,0 +1,9 @@
+DROP TABLE object_values_string;
+DROP TABLE object_values_integer;
+DROP TABLE object_values_boolean;
+DROP TABLE object_values_timestamp;
+DROP TABLE object_values_array;
+
+DROP TABLE objects;
+DROP TABLE attributes;
+DROP TYPE attribute_data_type;

--- a/migrations/2023-04-05-013204_eav/up.sql
+++ b/migrations/2023-04-05-013204_eav/up.sql
@@ -1,0 +1,58 @@
+CREATE TYPE attribute_data_type AS ENUM ('string', 'text', 'integer', 'boolean', 'timestamp', 'array');
+
+CREATE TABLE attributes (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    name varchar(255) NOT NULL UNIQUE,
+    data_type attribute_data_type NOT NULL,
+    description text,
+    reference_url varchar(255)
+);
+COMMENT ON TABLE attributes IS 'Attribute definitions that can be associated with objects like taxa records';
+COMMENT ON COLUMN attributes.id IS 'The attribute UUID. We use UUID to allow external source to generate and reference new attributes';
+COMMENT ON COLUMN attributes.name IS 'The unique name of an attribute';
+COMMENT ON COLUMN attributes.data_type IS 'The value type of the attribute. Used to query the correct object values table';
+COMMENT ON COLUMN attributes.description IS 'What the attribute represents';
+COMMENT ON COLUMN attributes.reference_url IS 'A link to the official definition of the attribute';
+
+
+CREATE TABLE objects (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_id uuid NOT NULL,
+    attribute_id uuid NOT NULL,
+    value_id uuid NOT NULL
+);
+COMMENT ON TABLE objects IS 'The entity-attribute-value association table';
+COMMENT ON COLUMN objects.id IS 'The object UUID. Having a UUID primary key allows external sources to generate and associate object in bulk';
+COMMENT ON COLUMN objects.attribute_id IS 'The attribute definition UUID. Links to the definition for this object association';
+COMMENT ON COLUMN objects.value_id IS 'The value UUID. Used with the attribute definition data type to retrieve the correct value from an object values table';
+
+
+CREATE TABLE object_values_string (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    value varchar(255) NOT NULL
+);
+
+CREATE TABLE object_values_text  (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    value text NOT NULL
+);
+
+CREATE TABLE object_values_integer (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    value bigint NOT NULL
+);
+
+CREATE TABLE object_values_boolean (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    value boolean NOT NULL
+);
+
+CREATE TABLE object_values_timestamp (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    value timestamp with time zone NOT NULL
+);
+
+CREATE TABLE object_values_array (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    value text[] NOT NULL
+);

--- a/src/http/admin/taxa.rs
+++ b/src/http/admin/taxa.rs
@@ -10,6 +10,7 @@ use serde::{Serialize, Deserialize};
 use uuid::Uuid;
 
 use crate::schema;
+use crate::schema_gnl;
 
 use crate::http::Context;
 use crate::http::error::InternalError;
@@ -28,7 +29,7 @@ async fn taxa(
     State(db_provider): State<Database>,
 ) -> Result<Json<TaxaList>, InternalError>
 {
-    use schema::gnl::dsl::*;
+    use schema_gnl::gnl::dsl::*;
     let mut conn = db_provider.pool.get().await?;
 
     // pagination

--- a/src/index/providers/db/family.rs
+++ b/src/index/providers/db/family.rs
@@ -12,7 +12,7 @@ impl GetFamily for Database {
     type Error = Error;
 
     async fn taxonomy(&self, name: &str) -> Result<Taxonomy, Error> {
-        use crate::schema::gnl::dsl::*;
+        use crate::schema_gnl::gnl::dsl::*;
         let mut conn = self.pool.get().await?;
 
         let taxon = gnl

--- a/src/index/providers/db/genus.rs
+++ b/src/index/providers/db/genus.rs
@@ -12,7 +12,7 @@ impl GetGenus for Database {
     type Error = Error;
 
     async fn taxonomy(&self, name: &str) -> Result<Taxonomy, Error> {
-        use crate::schema::gnl::dsl::*;
+        use crate::schema_gnl::gnl::dsl::*;
         let mut conn = self.pool.get().await?;
 
         let taxon = gnl

--- a/src/index/providers/db/models.rs
+++ b/src/index/providers/db/models.rs
@@ -3,6 +3,7 @@ use serde::{Serialize, Deserialize};
 use uuid::Uuid;
 
 use crate::schema;
+use crate::schema_gnl;
 
 
 #[derive(Clone, Queryable, Insertable, Debug, Default, Serialize, Deserialize)]
@@ -90,43 +91,43 @@ pub struct UserTaxaList {
 #[derive(Clone, Queryable, Insertable, Debug, Default, Serialize, Deserialize)]
 #[diesel(table_name = schema::user_taxa)]
 pub struct UserTaxon {
-    id: Uuid,
-    taxa_lists_id: Uuid,
+    pub id: Uuid,
+    pub taxa_lists_id: Uuid,
 
     // http://rs.tdwg.org/dwc/terms/scientificName
-    scientific_name: Option<String>,
+    pub scientific_name: Option<String>,
     // http://rs.tdwg.org/dwc/terms/scientificNameAuthorship
-    scientific_name_authorship: Option<String>,
+    pub scientific_name_authorship: Option<String>,
     // http://rs.gbif.org/terms/1.0/canonicalName
-    canonical_name: Option<String>,
+    pub canonical_name: Option<String>,
 
     // http://rs.tdwg.org/dwc/terms/specificEpithet
-    specific_epithet: Option<String>,
+    pub specific_epithet: Option<String>,
     // http://rs.tdwg.org/dwc/terms/infraspecificEpithet
-    infraspecific_epithet: Option<String>,
+    pub infraspecific_epithet: Option<String>,
     // http://rs.tdwg.org/dwc/terms/taxonRank
-    taxon_rank: Option<String>,
+    pub taxon_rank: Option<String>,
     // http://rs.tdwg.org/dwc/terms/nameAccordingTo
-    name_according_to: Option<String>,
+    pub name_according_to: Option<String>,
     // http://rs.tdwg.org/dwc/terms/namePublishedIn
-    name_published_in: Option<String>,
+    pub name_published_in: Option<String>,
     // http://rs.tdwg.org/dwc/terms/taxonomicStatus
-    taxonomic_status: Option<String>,
+    pub taxonomic_status: Option<String>,
     // http://rs.tdwg.org/dwc/terms/taxonRemarks
-    taxon_remarks: Option<String>,
+    pub taxon_remarks: Option<String>,
 
     // http://rs.tdwg.org/dwc/terms/kingdom
-    kingdom: Option<String>,
+    pub kingdom: Option<String>,
     // http://rs.tdwg.org/dwc/terms/phylum
-    phylum: Option<String>,
+    pub phylum: Option<String>,
     // http://rs.tdwg.org/dwc/terms/class
-    class: Option<String>,
+    pub class: Option<String>,
     // http://rs.tdwg.org/dwc/terms/order
-    order: Option<String>,
+    pub order: Option<String>,
     // http://rs.tdwg.org/dwc/terms/family
-    family: Option<String>,
+    pub family: Option<String>,
     // http://rs.tdwg.org/dwc/terms/genus
-    genus: Option<String>,
+    pub genus: Option<String>,
 }
 
 
@@ -141,7 +142,7 @@ pub struct User {
 
 
 #[derive(Clone, Queryable, Insertable, Debug, Default, Serialize, Deserialize)]
-#[diesel(table_name = schema::gnl)]
+#[diesel(table_name = schema_gnl::gnl)]
 pub struct ArgaTaxon {
     id: Uuid,
 

--- a/src/index/providers/db/models.rs
+++ b/src/index/providers/db/models.rs
@@ -183,3 +183,92 @@ pub struct ArgaTaxon {
     source: Option<String>,
     taxa_lists_id: Option<Uuid>,
 }
+
+
+
+#[derive(Debug, Deserialize, diesel_derive_enum::DbEnum)]
+#[ExistingTypePath = "crate::schema::sql_types::JobStatus"]
+pub enum JobStatus {
+    Pending,
+    Initialized,
+    Running,
+    Completed,
+    Failed,
+    Dead,
+}
+
+#[derive(Queryable, Debug, Deserialize)]
+#[diesel(table_name = schema::jobs)]
+pub struct Job {
+    pub id: Uuid,
+    pub status: JobStatus,
+    pub worker: String,
+    pub payload: Option<serde_json::Value>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+
+#[derive(Debug, Deserialize, diesel_derive_enum::DbEnum)]
+#[ExistingTypePath = "crate::schema::sql_types::AttributeDataType"]
+pub enum AttributeDataType {
+    String,
+    Text,
+    Integer,
+    Boolean,
+    Timestamp,
+    Array,
+}
+
+pub enum AttributeDataValue {
+    String(String),
+    Text(String),
+    Integer(i64),
+    Boolean(bool),
+    Timestamp(chrono::DateTime<chrono::Utc>),
+    Array(Vec<String>),
+}
+
+#[derive(Debug, Queryable)]
+pub struct Attribute {
+    pub id: Uuid,
+    pub name: String,
+    pub data_type: AttributeDataType,
+    pub description: Option<String>,
+    pub reference_url: Option<String>,
+}
+
+pub trait AttributeParser {
+    fn parse(&self, value: &Attribute) -> Option<AttributeDataValue>;
+}
+
+
+#[derive(Debug, Queryable, Insertable)]
+#[diesel(table_name = schema::objects)]
+pub struct Object {
+    pub id: Uuid,
+    pub entity_id: Uuid,
+    pub attribute_id: Uuid,
+    pub value_id: Uuid,
+}
+
+#[derive(Debug, Queryable, Insertable)]
+#[diesel(table_name = schema::object_values_string)]
+pub struct ObjectValueString {
+    pub id: Uuid,
+    pub value: String,
+}
+
+#[derive(Debug, Queryable, Insertable)]
+#[diesel(table_name = schema::object_values_text)]
+pub struct ObjectValueText {
+    pub id: Uuid,
+    pub value: String,
+}
+
+#[derive(Debug, Queryable, Insertable)]
+#[diesel(table_name = schema::object_values_array)]
+pub struct ObjectValueArray {
+    pub id: Uuid,
+    pub value: Vec<String>,
+}

--- a/src/index/providers/db/search.rs
+++ b/src/index/providers/db/search.rs
@@ -174,7 +174,7 @@ impl TaxaSearch for Database {
 
     #[tracing::instrument(skip(self))]
     async fn suggestions(&self, query: &str) ->  Result<Vec<SearchSuggestion> ,Self::Error> {
-        use crate::schema::gnl::dsl::*;
+        use crate::schema_gnl::gnl::dsl::*;
 
         if query.is_empty() {
             return Ok(vec![]);

--- a/src/index/providers/db/species.rs
+++ b/src/index/providers/db/species.rs
@@ -35,7 +35,7 @@ impl GetSpecies for Database {
     type Error = Error;
 
     async fn taxonomy(&self, name: &str) -> Result<Taxonomy, Error> {
-        use crate::schema::gnl::dsl::*;
+        use crate::schema_gnl::gnl::dsl::*;
         let mut conn = self.pool.get().await?;
 
         let taxon = gnl

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod schema;
+pub mod schema_gnl;
 pub mod features;
 pub mod http;
 pub mod index;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,5 +1,28 @@
 // @generated automatically by Diesel CLI.
 
+pub mod sql_types {
+    #[derive(diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "attribute_data_type"))]
+    pub struct AttributeDataType;
+
+    #[derive(diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "job_status"))]
+    pub struct JobStatus;
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::AttributeDataType;
+
+    attributes (id) {
+        id -> Uuid,
+        name -> Varchar,
+        data_type -> AttributeDataType,
+        description -> Nullable<Text>,
+        reference_url -> Nullable<Varchar>,
+    }
+}
+
 diesel::table! {
     descriptions (id) {
         id -> Uuid,
@@ -33,6 +56,20 @@ diesel::table! {
 }
 
 diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::JobStatus;
+
+    jobs (id) {
+        id -> Uuid,
+        status -> JobStatus,
+        worker -> Varchar,
+        payload -> Nullable<Jsonb>,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     media (id) {
         id -> Uuid,
         media_id -> Nullable<Int8>,
@@ -62,6 +99,57 @@ diesel::table! {
         event_date -> Nullable<Timestamptz>,
         license -> Nullable<Varchar>,
         rights_holder -> Nullable<Varchar>,
+    }
+}
+
+diesel::table! {
+    object_values_array (id) {
+        id -> Uuid,
+        value -> Array<Nullable<Text>>,
+    }
+}
+
+diesel::table! {
+    object_values_boolean (id) {
+        id -> Uuid,
+        value -> Bool,
+    }
+}
+
+diesel::table! {
+    object_values_integer (id) {
+        id -> Uuid,
+        value -> Int8,
+    }
+}
+
+diesel::table! {
+    object_values_string (id) {
+        id -> Uuid,
+        value -> Varchar,
+    }
+}
+
+diesel::table! {
+    object_values_text (id) {
+        id -> Uuid,
+        value -> Text,
+    }
+}
+
+diesel::table! {
+    object_values_timestamp (id) {
+        id -> Uuid,
+        value -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    objects (id) {
+        id -> Uuid,
+        entity_id -> Uuid,
+        attribute_id -> Uuid,
+        value_id -> Uuid,
     }
 }
 
@@ -148,35 +236,20 @@ diesel::table! {
     }
 }
 
-diesel::table! {
-    gnl (id) {
-        id -> Uuid,
-        scientific_name -> Nullable<Varchar>,
-        scientific_name_authorship -> Nullable<Varchar>,
-        canonical_name -> Nullable<Varchar>,
-        specific_epithet -> Nullable<Varchar>,
-        infraspecific_epithet -> Nullable<Varchar>,
-        taxon_rank -> Nullable<Text>,
-        name_according_to -> Nullable<Text>,
-        name_published_in -> Nullable<Text>,
-        taxonomic_status -> Nullable<Varchar>,
-        taxon_remarks -> Nullable<Text>,
-        kingdom -> Nullable<Varchar>,
-        phylum -> Nullable<Varchar>,
-        class -> Nullable<Varchar>,
-        order -> Nullable<Varchar>,
-        family -> Nullable<Varchar>,
-        genus -> Nullable<Varchar>,
-        source -> Nullable<Varchar>,
-        taxa_lists_id -> Nullable<Uuid>,
-    }
-}
-
 diesel::allow_tables_to_appear_in_same_query!(
+    attributes,
     descriptions,
     distribution,
+    jobs,
     media,
     media_observations,
+    object_values_array,
+    object_values_boolean,
+    object_values_integer,
+    object_values_string,
+    object_values_text,
+    object_values_timestamp,
+    objects,
     taxa,
     types_and_specimen,
     user_taxa,

--- a/src/schema_gnl.rs
+++ b/src/schema_gnl.rs
@@ -1,0 +1,23 @@
+diesel::table! {
+    gnl (id) {
+        id -> Uuid,
+        scientific_name -> Nullable<Varchar>,
+        scientific_name_authorship -> Nullable<Varchar>,
+        canonical_name -> Nullable<Varchar>,
+        specific_epithet -> Nullable<Varchar>,
+        infraspecific_epithet -> Nullable<Varchar>,
+        taxon_rank -> Nullable<Text>,
+        name_according_to -> Nullable<Text>,
+        name_published_in -> Nullable<Text>,
+        taxonomic_status -> Nullable<Varchar>,
+        taxon_remarks -> Nullable<Text>,
+        kingdom -> Nullable<Varchar>,
+        phylum -> Nullable<Varchar>,
+        class -> Nullable<Varchar>,
+        order -> Nullable<Varchar>,
+        family -> Nullable<Varchar>,
+        genus -> Nullable<Varchar>,
+        source -> Nullable<Varchar>,
+        taxa_lists_id -> Nullable<Uuid>,
+    }
+}


### PR DESCRIPTION
This adds an experimental [EAV](https://en.wikipedia.org/wiki/Entity%E2%80%93attribute%E2%80%93value_model) table to store attributes that describe a taxon but don't fall under the common fields for the ARGA GNL.
It should enable arbitrary data so long as it is one of the supported types and the attribute is defined. The primary purpose for this branch is to enable custom taxon traits entered by a user via the admin backend which is then folded in with the ARGA GNL to provide enriched data. The idea here is to then index the ARGA GNL so that it is just another source of data for pipelines, but that task remains as a future experiment.

The branch is being developed along with the `feature/workers` branch as a proof of concept to process and store enriched data from an AFD export.