### PR TITLE
removed taxonomic act types as they are no longer necessary

### DIFF
--- a/core/migrations/2024-10-17-064537_remove_taxonomic_acts_act/down.sql
+++ b/core/migrations/2024-10-17-064537_remove_taxonomic_acts_act/down.sql
@@ -1,0 +1,11 @@
+CREATE TYPE taxonomic_act_type AS ENUM (
+  'accepted',
+  'unaccepted',
+  'synonym',
+  'homonym',
+  'nomenclatural_synonym',
+  'taxonomic_synonym',
+  'replaced_synonym'
+);
+
+ALTER TABLE taxonomic_acts ADD COLUMN act taxonomic_act_type NOT NULL;

--- a/core/migrations/2024-10-17-064537_remove_taxonomic_acts_act/up.sql
+++ b/core/migrations/2024-10-17-064537_remove_taxonomic_acts_act/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE taxonomic_acts DROP COLUMN act;
+DROP TYPE taxonomic_act_type;

--- a/core/src/models/mod.rs
+++ b/core/src/models/mod.rs
@@ -716,29 +716,15 @@ pub struct NomenclaturalAct {
     pub publication_id: Uuid,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, diesel_derive_enum::DbEnum)]
-#[ExistingTypePath = "schema::sql_types::TaxonomicActType"]
-pub enum TaxonomicActType {
-    Unaccepted,
-    Accepted,
-    Synonym,
-    Homonym,
-    NomenclaturalSynonym,
-    TaxonomicSynonym,
-    ReplacedSynonym,
-}
-
 #[derive(Queryable, Selectable, Insertable, Debug, Serialize, Deserialize)]
 #[diesel(table_name = schema::taxonomic_acts)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct TaxonomicAct {
     pub id: Uuid,
     pub entity_id: String,
     pub taxon_id: Uuid,
     pub accepted_taxon_id: Option<Uuid>,
-
-    pub act: TaxonomicActType,
     pub source_url: Option<String>,
-
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub data_created_at: Option<DateTime<Utc>>,

--- a/core/src/models/operation_logs.rs
+++ b/core/src/models/operation_logs.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use strum::Display;
 use uuid::Uuid;
 
-use super::{schema, Dataset, DatasetVersion, PublicationType, TaxonomicActType, TaxonomicRank, TaxonomicStatus};
+use super::{schema, Dataset, DatasetVersion, PublicationType, TaxonomicRank, TaxonomicStatus};
 use crate::crdt::DataFrameOperation;
 use crate::models::NomenclaturalActType;
 
@@ -130,7 +130,6 @@ pub enum TaxonomicActAtom {
     PublicationDate(String),
     Taxon(String),
     AcceptedTaxon(String),
-    Act(TaxonomicActType),
     SourceUrl(String),
     CreatedAt(DateTime<Utc>),
     UpdatedAt(DateTime<Utc>),

--- a/core/src/schema.rs
+++ b/core/src/schema.rs
@@ -46,10 +46,6 @@ pub mod sql_types {
     pub struct SourceContentType;
 
     #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
-    #[diesel(postgres_type(name = "taxonomic_act_type"))]
-    pub struct TaxonomicActType;
-
-    #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "taxonomic_rank"))]
     pub struct TaxonomicRank;
 
@@ -830,15 +826,11 @@ diesel::table! {
 }
 
 diesel::table! {
-    use diesel::sql_types::*;
-    use super::sql_types::TaxonomicActType;
-
     taxonomic_acts (id) {
         id -> Uuid,
         entity_id -> Varchar,
         taxon_id -> Uuid,
         accepted_taxon_id -> Nullable<Uuid>,
-        act -> TaxonomicActType,
         source_url -> Nullable<Varchar>,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,

--- a/server/src/database/taxa.rs
+++ b/server/src/database/taxa.rs
@@ -6,7 +6,6 @@ use arga_core::models::{
     Publication,
     Taxon,
     TaxonTreeNode,
-    TaxonomicActType,
     TaxonomicRank,
     ACCEPTED_NAMES,
     SPECIES_RANKS,
@@ -104,7 +103,6 @@ pub struct TaxonomicAct {
     pub entity_id: String,
     pub taxon: Taxon,
     pub accepted_taxon: Option<Taxon>,
-    pub act: TaxonomicActType,
     pub source_url: Option<String>,
     pub data_created_at: Option<DateTime<Utc>>,
     pub data_updated_at: Option<DateTime<Utc>>,
@@ -463,7 +461,6 @@ impl TaxaProvider {
                 accepted
                     .fields(<Taxon as Selectable<diesel::pg::Pg>>::construct_selection())
                     .nullable(),
-                acts::act,
                 acts::source_url,
                 acts::data_created_at,
                 acts::data_updated_at,

--- a/server/src/http/graphql/common/taxonomy.rs
+++ b/server/src/http/graphql/common/taxonomy.rs
@@ -187,19 +187,6 @@ pub enum NomenclaturalActType {
 
 
 #[derive(Enum, Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[graphql(remote = "models::TaxonomicActType")]
-pub enum TaxonomicActType {
-    Unaccepted,
-    Accepted,
-    Synonym,
-    Homonym,
-    NomenclaturalSynonym,
-    TaxonomicSynonym,
-    ReplacedSynonym,
-}
-
-
-#[derive(Enum, Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[graphql(remote = "models::TaxonomicVernacularGroup")]
 pub enum TaxonomicVernacularGroup {
     FloweringPlants,

--- a/server/src/http/graphql/taxon.rs
+++ b/server/src/http/graphql/taxon.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::common::datasets::DatasetDetails;
-use super::common::taxonomy::{NomenclaturalActType, TaxonDetails, TaxonomicActType, TaxonomicRank, TaxonomicStatus};
+use super::common::taxonomy::{NomenclaturalActType, TaxonDetails, TaxonomicRank, TaxonomicStatus};
 use super::common::NameDetails;
 use crate::database::extensions::classification_filters::Classification;
 use crate::database::{taxa, Database};
@@ -323,7 +323,6 @@ impl From<taxa::NomenclaturalAct> for NomenclaturalAct {
 #[derive(SimpleObject)]
 pub struct TaxonomicAct {
     pub entity_id: String,
-    pub act: TaxonomicActType,
     pub source_url: Option<String>,
     pub taxon: TaxonDetails,
     pub accepted_taxon: Option<TaxonDetails>,
@@ -335,7 +334,6 @@ impl From<taxa::TaxonomicAct> for TaxonomicAct {
     fn from(value: taxa::TaxonomicAct) -> Self {
         Self {
             entity_id: value.entity_id,
-            act: value.act.into(),
             source_url: value.source_url,
             taxon: value.taxon.into(),
             accepted_taxon: value.accepted_taxon.map(|t| t.into()),

--- a/tasks/src/data/mod.rs
+++ b/tasks/src/data/mod.rs
@@ -1,8 +1,8 @@
 pub mod bpa;
 pub mod ncbi;
 // pub mod bold;
-pub mod oplogger;
-pub mod plazi;
+// pub mod oplogger;
+// pub mod plazi;
 
 #[derive(clap::Subcommand)]
 pub enum Command {
@@ -15,11 +15,10 @@ pub enum Command {
     // Extra processing for BOLD datasets
     // #[command(subcommand)]
     // Bold(bold::Command),
-    #[command(subcommand)]
-    Plazi(plazi::Command),
-
-    #[command(subcommand)]
-    Oplog(oplogger::Command),
+    // #[command(subcommand)]
+    // Plazi(plazi::Command),
+    // #[command(subcommand)]
+    // Oplog(oplogger::Command),
 }
 
 pub fn process_command(command: &Command) {
@@ -29,8 +28,8 @@ pub fn process_command(command: &Command) {
         Command::Ncbi(cmd) => ncbi::process_command(cmd),
         Command::Bpa(cmd) => bpa::process_command(cmd),
         // Command::Bold(cmd) => bold::process_command(cmd),
-        Command::Plazi(cmd) => plazi::process_command(cmd),
-        Command::Oplog(cmd) => oplogger::process_command(cmd),
+        // Command::Plazi(cmd) => plazi::process_command(cmd),
+        // Command::Oplog(cmd) => oplogger::process_command(cmd),
     }
 }
 

--- a/tasks/src/data/plazi/treatments.rs
+++ b/tasks/src/data/plazi/treatments.rs
@@ -39,7 +39,7 @@ use super::formatting::{
     Uri,
     Uuid,
 };
-use crate::data::oplogger::get_pool;
+// use crate::data::oplogger::get_pool;
 use crate::data::plazi::formatting::{Span, SpanStack};
 use crate::data::{Error, ParseError};
 

--- a/workers/src/extractors/mod.rs
+++ b/workers/src/extractors/mod.rs
@@ -24,4 +24,4 @@ pub mod subsample_extractor;
 pub mod classification_extractor;
 pub mod name_publication_extractor;
 pub mod nomenclatural_act_extractor;
-pub mod taxonomic_act_extractor;
+// pub mod taxonomic_act_extractor;

--- a/workers/src/importers/mod.rs
+++ b/workers/src/importers/mod.rs
@@ -23,4 +23,4 @@ pub mod subsample_importer;
 pub mod classification_importer;
 pub mod name_publication_importer;
 pub mod nomenclatural_act_importer;
-pub mod taxonomic_act_importer;
+// pub mod taxonomic_act_importer;

--- a/workers/src/threaded_job.rs
+++ b/workers/src/threaded_job.rs
@@ -34,7 +34,7 @@ use super::importers::{
     // taxon_importer,
     taxon_history_importer,
     taxon_photo_importer,
-    taxonomic_act_importer,
+    // taxonomic_act_importer,
     vernacular_importer,
 };
 
@@ -139,7 +139,7 @@ impl ThreadedJob {
             "import_classification" => classification_importer::import(path, pool)?,
             "import_name_publication" => name_publication_importer::import(path, &dataset?, pool)?,
             "import_nomenclatural_act" => nomenclatural_act_importer::import(path, pool)?,
-            "import_taxonomic_act" => taxonomic_act_importer::import(path, pool)?,
+            // "import_taxonomic_act" => taxonomic_act_importer::import(path, pool)?,
             _ => panic!("Unknown job worker: {}", worker),
         }
 


### PR DESCRIPTION
we're now using nomenclatural acts exclusively for the timeline visualisations and the act column for taxonomic act was never very informative due to it being derived from the taxonomic status