### PR TITLE
Adds more granular stats to the name_data_summaries and taxa_tree_stats views.

### DIFF
--- a/core/migrations/2025-01-15-071342_add_genome_breakdown_stats_to_name_data_summaries/down.sql
+++ b/core/migrations/2025-01-15-071342_add_genome_breakdown_stats_to_name_data_summaries/down.sql
@@ -1,0 +1,150 @@
+-- drop dependent views and recreate them all
+DROP MATERIALIZED VIEW taxa_tree_stats;
+DROP MATERIALIZED VIEW species;
+DROP MATERIALIZED VIEW name_data_summaries;
+
+
+
+CREATE MATERIALIZED VIEW name_data_summaries AS
+SELECT
+    names.id AS name_id,
+    COALESCE(markers.total, 0) AS markers,
+    COALESCE(genomes.total, 0) AS genomes,
+    COALESCE(specimens.total, 0) AS specimens,
+    COALESCE(other_data.total, 0) AS other,
+    COALESCE(markers.total, 0) + COALESCE(genomes.total, 0) + COALESCE(other_data.total, 0) AS total_genomic
+FROM names
+LEFT JOIN (
+     SELECT name_id, count(*)::int AS total
+     FROM sequencing_events
+     JOIN sequences ON sequencing_events.sequence_id = sequences.id
+     WHERE target_gene IS NOT NULL
+     GROUP BY name_id
+) markers ON markers.name_id = names.id
+
+LEFT JOIN (
+     SELECT name_id, count(*)::int AS total
+     FROM assembly_events
+     JOIN sequences ON assembly_events.sequence_id = sequences.id
+     GROUP BY name_id
+) genomes ON genomes.name_id = names.id
+
+LEFT JOIN (
+     SELECT name_id, count(*)::int AS total
+     FROM specimens
+     GROUP BY name_id
+) specimens ON specimens.name_id = names.id
+
+LEFT JOIN (
+     SELECT name_id, count(*)::int as total
+     FROM sequences
+     LEFT JOIN sequencing_events se on sequences.id = se.sequence_id
+     LEFT JOIN assembly_events on sequences.id = assembly_events.sequence_id
+     LEFT JOIN annotation_events ae on sequences.id = ae.sequence_id
+     WHERE assembly_events.id IS NULL AND target_gene IS NULL
+     GROUP BY name_id
+) other_data ON other_data.name_id = names.id;
+
+
+
+
+CREATE MATERIALIZED VIEW taxa_tree_stats AS
+SELECT
+    taxon_id,
+    taxon_stats.id,
+    SUM(loci) AS loci,
+    SUM(genomes) AS genomes,
+    SUM(specimens) AS specimens,
+    SUM(other) AS other,
+    SUM(total_genomic) AS total_genomic,
+    SUM(CASE WHEN taxa.rank='species' THEN 1 ELSE 0 END) AS species
+FROM (
+    SELECT
+        taxa_tree.taxon_id,
+        id,
+        path_id,
+        FIRST_VALUE(loci) OVER tree_paths AS loci,
+        FIRST_VALUE(genomes) OVER tree_paths AS genomes,
+        FIRST_VALUE(specimens) OVER tree_paths AS specimens,
+        FIRST_VALUE(other) OVER tree_paths AS other,
+        FIRST_VALUE(total_genomic) OVER tree_paths AS total_genomic
+    FROM taxa_tree
+    -- a taxon can have multiple alternate names so we group them
+    -- up and sum it here otherwise it will cause double counting
+    LEFT JOIN (
+        SELECT
+            taxon_id,
+            SUM(markers) AS loci,
+            SUM(genomes) AS genomes,
+            SUM(specimens) AS specimens,
+            SUM(other) AS other,
+            SUM(total_genomic) AS total_genomic
+        FROM name_data_summaries
+        JOIN taxon_names ON taxon_names.name_id = name_data_summaries.name_id
+        GROUP BY taxon_id
+    ) summed ON summed.taxon_id = taxa_tree.id
+    WINDOW tree_paths AS (partition by path_id order by depth)
+    ORDER BY path_id, depth
+) taxon_stats
+JOIN taxa ON taxon_stats.path_id = taxa.id
+GROUP BY taxon_id, taxon_stats.id;
+
+CREATE INDEX taxa_tree_stats_taxon_id ON taxa_tree_stats (taxon_id);
+CREATE INDEX taxa_tree_stats_id ON taxa_tree_stats (id);
+
+
+
+
+CREATE MATERIALIZED VIEW species AS
+SELECT
+    taxa.id,
+    taxa.scientific_name,
+    taxa.canonical_name,
+    taxa.authorship,
+    taxa.dataset_id,
+    taxa.status,
+    taxa.rank,
+    taxa_tree.classification,
+    summaries.genomes,
+    summaries.loci,
+    summaries.specimens,
+    summaries.other,
+    summaries.total_genomic,
+    name_attributes.traits,
+    vernacular_names.names AS vernacular_names
+FROM taxa
+JOIN (
+  SELECT
+      taxon_id,
+      jsonb_object_agg(rank, canonical_name) AS classification
+  FROM taxa_dag
+  GROUP BY taxon_id
+) taxa_tree ON taxa.parent_id = taxa_tree.taxon_id
+JOIN (
+  SELECT
+      taxon_id,
+      SUM(genomes) AS genomes,
+      SUM(markers) AS loci,
+      SUM(specimens) AS specimens,
+      SUM(other) AS other,
+      SUM(total_genomic) AS total_genomic
+  FROM name_data_summaries
+  JOIN taxon_names ON taxon_names.name_id = name_data_summaries.name_id
+  GROUP BY taxon_id
+) summaries ON taxa.id = summaries.taxon_id
+LEFT JOIN (
+  SELECT
+    taxon_id,
+    array_agg(name::text) filter (WHERE value_type = 'boolean') AS traits
+  FROM name_attributes
+  JOIN taxon_names ON taxon_names.name_id = name_attributes.name_id
+  GROUP BY taxon_id
+) name_attributes ON taxa.id = name_attributes.taxon_id
+LEFT JOIN (
+  SELECT
+    taxon_id,
+    array_agg(DISTINCT vernacular_name) as names
+  FROM vernacular_names
+  JOIN taxon_names ON taxon_names.name_id = vernacular_names.name_id
+  GROUP BY taxon_id
+) vernacular_names ON taxa.id = vernacular_names.taxon_id;

--- a/core/migrations/2025-01-15-071342_add_genome_breakdown_stats_to_name_data_summaries/up.sql
+++ b/core/migrations/2025-01-15-071342_add_genome_breakdown_stats_to_name_data_summaries/up.sql
@@ -1,0 +1,95 @@
+-- we have to drop all the views that depend on name_data_summaries and recreate them.
+-- fortunately we usually want this anyway since adding or removing fields normally needs
+-- to be propagated to the dependent views
+DROP MATERIALIZED VIEW taxa_tree_stats;
+DROP MATERIALIZED VIEW species;
+DROP MATERIALIZED VIEW name_data_summaries;
+
+
+CREATE MATERIALIZED VIEW name_data_summaries AS
+SELECT
+    names.id AS name_id,
+    COALESCE(markers.total, 0) AS markers,
+    COALESCE(genomes.total, 0) AS genomes,
+    COALESCE(specimens.total, 0) AS specimens,
+    COALESCE(other_data.total, 0) AS other,
+    COALESCE(markers.total, 0) + COALESCE(genomes.total, 0) + COALESCE(other_data.total, 0) AS total_genomic,
+    COALESCE(complete_genomes.total, 0) AS complete_genomes,
+    COALESCE(partial_genomes.total, 0) AS partial_genomes,
+    COALESCE(assembly_chromosomes.total, 0) AS assembly_chromosomes,
+    COALESCE(assembly_scaffolds.total, 0) AS assembly_scaffolds,
+    COALESCE(assembly_contigs.total, 0) AS assembly_contigs
+FROM names
+LEFT JOIN (
+     SELECT name_id, count(*)::int AS total
+     FROM sequencing_events
+     JOIN sequences ON sequencing_events.sequence_id = sequences.id
+     WHERE target_gene IS NOT NULL
+     GROUP BY name_id
+) markers ON markers.name_id = names.id
+
+LEFT JOIN (
+     SELECT name_id, count(*)::int AS total
+     FROM assembly_events
+     JOIN sequences ON assembly_events.sequence_id = sequences.id
+     GROUP BY name_id
+) genomes ON genomes.name_id = names.id
+
+LEFT JOIN (
+     SELECT name_id, count(*)::int AS total
+     FROM specimens
+     GROUP BY name_id
+) specimens ON specimens.name_id = names.id
+
+LEFT JOIN (
+     SELECT name_id, count(*)::int as total
+     FROM sequences
+     LEFT JOIN sequencing_events se on sequences.id = se.sequence_id
+     LEFT JOIN assembly_events on sequences.id = assembly_events.sequence_id
+     LEFT JOIN annotation_events ae on sequences.id = ae.sequence_id
+     WHERE assembly_events.id IS NULL AND target_gene IS NULL
+     GROUP BY name_id
+) other_data ON other_data.name_id = names.id
+
+LEFT JOIN (
+     SELECT name_id, count(*)::int AS total
+     FROM assembly_events
+     JOIN sequences ON assembly_events.sequence_id = sequences.id
+     WHERE quality = 'Complete Genome'
+     GROUP BY name_id
+) complete_genomes ON complete_genomes.name_id = names.id
+
+LEFT JOIN (
+     SELECT name_id, count(*)::int AS total
+     FROM annotation_events
+     JOIN sequences ON annotation_events.sequence_id = sequences.id
+     WHERE representation = 'Partial'
+     GROUP BY name_id
+) partial_genomes ON partial_genomes.name_id = names.id
+
+LEFT JOIN (
+     SELECT name_id, count(*)::int AS total
+     FROM assembly_events
+     JOIN sequences ON assembly_events.sequence_id = sequences.id
+     WHERE quality = 'Chromosome'
+     GROUP BY name_id
+) assembly_chromosomes ON assembly_chromosomes.name_id = names.id
+
+LEFT JOIN (
+     SELECT name_id, count(*)::int AS total
+     FROM assembly_events
+     JOIN sequences ON assembly_events.sequence_id = sequences.id
+     WHERE quality = 'Scaffold'
+     GROUP BY name_id
+) assembly_scaffolds ON assembly_scaffolds.name_id = names.id
+
+LEFT JOIN (
+     SELECT name_id, count(*)::int AS total
+     FROM assembly_events
+     JOIN sequences ON assembly_events.sequence_id = sequences.id
+     WHERE quality = 'Contig'
+     GROUP BY name_id
+) assembly_contigs ON assembly_contigs.name_id = names.id;
+
+
+CREATE UNIQUE INDEX name_data_summaries_name_id ON name_data_summaries (name_id);

--- a/core/migrations/2025-01-15-074937_add_genome_breakdown_stats_to_taxa_tree_stats/down.sql
+++ b/core/migrations/2025-01-15-074937_add_genome_breakdown_stats_to_taxa_tree_stats/down.sql
@@ -1,0 +1,2 @@
+-- this is not actually a reversible migration but we drop the view anyway for development convenience
+DROP MATERIALIZED VIEW taxa_tree_stats;

--- a/core/migrations/2025-01-15-074937_add_genome_breakdown_stats_to_taxa_tree_stats/up.sql
+++ b/core/migrations/2025-01-15-074937_add_genome_breakdown_stats_to_taxa_tree_stats/up.sql
@@ -1,0 +1,81 @@
+CREATE MATERIALIZED VIEW taxa_tree_stats AS
+-- combines the name_data_summaries of names that are linked to one another.
+-- this allows us to present data from dark taxa
+WITH taxa_data_summaries AS (
+     SELECT
+        taxon_id,
+        SUM(markers) AS loci,
+        SUM(genomes) AS genomes,
+        SUM(specimens) AS specimens,
+        SUM(other) AS other,
+        SUM(total_genomic) AS total_genomic,
+        SUM(complete_genomes) AS complete_genomes,
+        SUM(partial_genomes) AS partial_genomes,
+        SUM(assembly_chromosomes) AS assembly_chromosomes,
+        SUM(assembly_scaffolds) AS assembly_scaffolds,
+        SUM(assembly_contigs) AS assembly_contigs
+    FROM name_data_summaries
+    JOIN taxon_names ON taxon_names.name_id = name_data_summaries.name_id
+    GROUP BY taxon_id
+),
+-- the linked name_data_summaries joined with the taxa_tree to get stats that
+-- aggregate up the taxa hierarchy for each taxon
+taxon_stats AS (
+    SELECT
+        taxa_tree.taxon_id,
+        id,
+        path_id,
+        depth,
+        FIRST_VALUE(loci) OVER tree_paths AS loci,
+        FIRST_VALUE(genomes) OVER tree_paths AS genomes,
+        FIRST_VALUE(specimens) OVER tree_paths AS specimens,
+        FIRST_VALUE(other) OVER tree_paths AS other,
+        FIRST_VALUE(total_genomic) OVER tree_paths AS total_genomic,
+        FIRST_VALUE(complete_genomes) OVER tree_paths AS complete_genomes,
+        FIRST_VALUE(partial_genomes) OVER tree_paths AS partial_genomes,
+        FIRST_VALUE(assembly_chromosomes) OVER tree_paths AS assembly_chromosomes,
+        FIRST_VALUE(assembly_scaffolds) OVER tree_paths AS assembly_scaffolds,
+        FIRST_VALUE(assembly_contigs) OVER tree_paths AS assembly_contigs
+    FROM taxa_tree
+    -- a taxon can have multiple alternate names so we group them
+    -- up and sum it here otherwise it will cause double counting
+    LEFT JOIN taxa_data_summaries ON taxa_data_summaries.taxon_id = taxa_tree.id
+    WINDOW tree_paths AS (partition by path_id order by depth)
+    ORDER BY path_id, depth
+),
+-- the grouped up stats for higher taxonomy. it joins the taxon_stats on the
+-- path_id to get the accumulated amounts of all descendents and then groups
+-- by the taxon id itself to ensure that all paths are folded in to the parent taxon
+stats AS (
+    SELECT
+        taxon_id,
+        taxon_stats.id,
+        MAX(depth) AS tree_depth,
+        SUM(loci) AS loci,
+        SUM(genomes) AS genomes,
+        SUM(specimens) AS specimens,
+        SUM(other) AS other,
+        SUM(total_genomic) AS total_genomic,
+        SUM(CASE WHEN taxa.rank='species' THEN 1 ELSE 0 END) AS species,
+        SUM(complete_genomes) AS complete_genomes,
+        SUM(partial_genomes) AS partial_genomes,
+        SUM(assembly_chromosomes) AS assembly_chromosomes,
+        SUM(assembly_scaffolds) AS assembly_scaffolds,
+        SUM(assembly_contigs) AS assembly_contigs
+    FROM taxon_stats
+    JOIN taxa ON taxon_stats.path_id = taxa.id
+    GROUP BY taxon_id, taxon_stats.id
+)
+-- the main query. simply join the tree stats with the taxon and sum the stats for each node
+SELECT
+    stats.*,
+    CASE WHEN species > 0 THEN (complete_genomes / species) ELSE 0 END AS complete_genomes_coverage,
+    CASE WHEN species > 0 THEN (partial_genomes / species) ELSE 0 END AS partial_genomes_coverageb,
+    CASE WHEN species > 0 THEN (assembly_chromosomes / species) ELSE 0 END AS assembly_chromosomes_coverage,
+    CASE WHEN species > 0 THEN (assembly_scaffolds / species) ELSE 0 END AS assembly_scaffolds_coverage,
+    CASE WHEN species > 0 THEN (assembly_contigs / species) ELSE 0 END AS assembly_contigs_coverage
+FROM stats
+;
+
+CREATE INDEX taxa_tree_stats_taxon_id ON taxa_tree_stats (taxon_id);
+CREATE INDEX taxa_tree_stats_id ON taxa_tree_stats (id);

--- a/core/migrations/2025-01-15-074937_add_genome_breakdown_stats_to_taxa_tree_stats/up.sql
+++ b/core/migrations/2025-01-15-074937_add_genome_breakdown_stats_to_taxa_tree_stats/up.sql
@@ -26,6 +26,11 @@ taxon_stats AS (
         id,
         path_id,
         depth,
+        -- if the node is the second taxon in the path then its the direct parent of
+        -- leaf node, so we use the value of 1 to allow summing when grouped. this allows
+        -- us to determine how many direct children each node has
+        CASE WHEN depth = 1 THEN 1 ELSE 0 END AS direct_parent,
+        -- pull the the values from the name data summaries
         FIRST_VALUE(loci) OVER tree_paths AS loci,
         FIRST_VALUE(genomes) OVER tree_paths AS genomes,
         FIRST_VALUE(specimens) OVER tree_paths AS specimens,
@@ -35,12 +40,21 @@ taxon_stats AS (
         FIRST_VALUE(partial_genomes) OVER tree_paths AS partial_genomes,
         FIRST_VALUE(assembly_chromosomes) OVER tree_paths AS assembly_chromosomes,
         FIRST_VALUE(assembly_scaffolds) OVER tree_paths AS assembly_scaffolds,
-        FIRST_VALUE(assembly_contigs) OVER tree_paths AS assembly_contigs
+        FIRST_VALUE(assembly_contigs) OVER tree_paths AS assembly_contigs,
+        -- base values for coverage stats. if there is at least one type of data we consider
+        -- it full coverage for the node. this is useful further on when summarising a node
+        -- and comparing the total coverage against the amount of children to determine coverage
+        -- for a node at any part of the hierarchy without losing that information to aggregation
+        CASE WHEN FIRST_VALUE(complete_genomes) OVER tree_paths > 0 THEN 1 ELSE 0 END AS complete_genomes_coverage,
+        CASE WHEN FIRST_VALUE(partial_genomes) OVER tree_paths > 0 THEN 1 ELSE 0 END AS partial_genomes_coverage,
+        CASE WHEN FIRST_VALUE(assembly_chromosomes) OVER tree_paths > 0 THEN 1 ELSE 0 END AS assembly_chromosomes_coverage,
+        CASE WHEN FIRST_VALUE(assembly_scaffolds) OVER tree_paths > 0 THEN 1 ELSE 0 END AS assembly_scaffolds_coverage,
+        CASE WHEN FIRST_VALUE(assembly_contigs) OVER tree_paths > 0 THEN 1 ELSE 0 END AS assembly_contigs_coverage
     FROM taxa_tree
     -- a taxon can have multiple alternate names so we group them
     -- up and sum it here otherwise it will cause double counting
     LEFT JOIN taxa_data_summaries ON taxa_data_summaries.taxon_id = taxa_tree.id
-    WINDOW tree_paths AS (partition by path_id order by depth)
+    WINDOW tree_paths AS (partition BY path_id ORDER BY depth)
     ORDER BY path_id, depth
 ),
 -- the grouped up stats for higher taxonomy. it joins the taxon_stats on the
@@ -51,6 +65,8 @@ stats AS (
         taxon_id,
         taxon_stats.id,
         MAX(depth) AS tree_depth,
+        SUM(direct_parent) AS children,
+        COUNT(*) - 1 AS descendants,
         SUM(loci) AS loci,
         SUM(genomes) AS genomes,
         SUM(specimens) AS specimens,
@@ -61,21 +77,20 @@ stats AS (
         SUM(partial_genomes) AS partial_genomes,
         SUM(assembly_chromosomes) AS assembly_chromosomes,
         SUM(assembly_scaffolds) AS assembly_scaffolds,
-        SUM(assembly_contigs) AS assembly_contigs
+        SUM(assembly_contigs) AS assembly_contigs,
+        -- sum up all the coverage for the node and divide it by the amount of children to determine
+        -- the total coverage for this specific node
+        SUM(complete_genomes_coverage) AS total_complete_genomes_coverage,
+        SUM(partial_genomes_coverage) AS total_partial_genomes_coverage,
+        SUM(assembly_chromosomes_coverage) AS total_assembly_chromosomes_coverage,
+        SUM(assembly_scaffolds_coverage) AS total_assembly_scaffolds_coverage,
+        SUM(assembly_contigs_coverage) AS total_assembly_contigs_coverage
     FROM taxon_stats
     JOIN taxa ON taxon_stats.path_id = taxa.id
     GROUP BY taxon_id, taxon_stats.id
 )
 -- the main query. simply join the tree stats with the taxon and sum the stats for each node
-SELECT
-    stats.*,
-    CASE WHEN species > 0 THEN (complete_genomes / species) ELSE 0 END AS complete_genomes_coverage,
-    CASE WHEN species > 0 THEN (partial_genomes / species) ELSE 0 END AS partial_genomes_coverageb,
-    CASE WHEN species > 0 THEN (assembly_chromosomes / species) ELSE 0 END AS assembly_chromosomes_coverage,
-    CASE WHEN species > 0 THEN (assembly_scaffolds / species) ELSE 0 END AS assembly_scaffolds_coverage,
-    CASE WHEN species > 0 THEN (assembly_contigs / species) ELSE 0 END AS assembly_contigs_coverage
-FROM stats
-;
+SELECT * FROM stats;
 
 CREATE INDEX taxa_tree_stats_taxon_id ON taxa_tree_stats (taxon_id);
 CREATE INDEX taxa_tree_stats_id ON taxa_tree_stats (id);

--- a/core/migrations/2025-01-15-080356_add_genome_breakdown_stats_to_species/down.sql
+++ b/core/migrations/2025-01-15-080356_add_genome_breakdown_stats_to_species/down.sql
@@ -1,0 +1,2 @@
+-- this is not actually a reversible migration but we drop the view anyway for development convenience
+DROP MATERIALIZED VIEW species;

--- a/core/migrations/2025-01-15-080356_add_genome_breakdown_stats_to_species/up.sql
+++ b/core/migrations/2025-01-15-080356_add_genome_breakdown_stats_to_species/up.sql
@@ -1,0 +1,63 @@
+CREATE MATERIALIZED VIEW species AS
+SELECT
+    taxa.id,
+    taxa.scientific_name,
+    taxa.canonical_name,
+    taxa.authorship,
+    taxa.dataset_id,
+    taxa.status,
+    taxa.rank,
+    taxa_tree.classification,
+    summaries.genomes,
+    summaries.loci,
+    summaries.specimens,
+    summaries.other,
+    summaries.total_genomic,
+    summaries.complete_genomes,
+    summaries.partial_genomes,
+    summaries.assembly_chromosomes,
+    summaries.assembly_scaffolds,
+    summaries.assembly_contigs,
+    name_attributes.traits,
+    vernacular_names.names AS vernacular_names
+FROM taxa
+JOIN (
+  SELECT
+      taxon_id,
+      jsonb_object_agg(rank, canonical_name) AS classification
+  FROM taxa_dag
+  GROUP BY taxon_id
+) taxa_tree ON taxa.parent_id = taxa_tree.taxon_id
+JOIN (
+  SELECT
+      taxon_id,
+      SUM(genomes) AS genomes,
+      SUM(markers) AS loci,
+      SUM(specimens) AS specimens,
+      SUM(other) AS other,
+      SUM(total_genomic) AS total_genomic,
+      SUM(complete_genomes) AS complete_genomes,
+      SUM(partial_genomes) AS partial_genomes,
+      SUM(assembly_chromosomes) AS assembly_chromosomes,
+      SUM(assembly_scaffolds) AS assembly_scaffolds,
+      SUM(assembly_contigs) AS assembly_contigs
+  FROM name_data_summaries
+  JOIN taxon_names ON taxon_names.name_id = name_data_summaries.name_id
+  GROUP BY taxon_id
+) summaries ON taxa.id = summaries.taxon_id
+LEFT JOIN (
+  SELECT
+    taxon_id,
+    array_agg(name::text) filter (WHERE value_type = 'boolean') AS traits
+  FROM name_attributes
+  JOIN taxon_names ON taxon_names.name_id = name_attributes.name_id
+  GROUP BY taxon_id
+) name_attributes ON taxa.id = name_attributes.taxon_id
+LEFT JOIN (
+  SELECT
+    taxon_id,
+    array_agg(DISTINCT vernacular_name) as names
+  FROM vernacular_names
+  JOIN taxon_names ON taxon_names.name_id = vernacular_names.name_id
+  GROUP BY taxon_id
+) vernacular_names ON taxa.id = vernacular_names.taxon_id;


### PR DESCRIPTION
There are two main changes to the mentioned two views.
The first is counting how many of a particular type of genomic data exists for each name, and then aggregated up the hierarchy in all taxa trees. The breakdown of genomic data are:
- complete genomes
- partial genomes
- chromosomes
- scaffolds
- contigs

The second is adding a coverage value which counts how many species have that particular type of data so that it can be used in other views for determining the overall coverage of a taxon in any tree