### PR TITLE
adds the new genome breakdown stats to the stats api endpoint.

### DIFF
--- a/core/src/schema_gnl.rs
+++ b/core/src/schema_gnl.rs
@@ -89,6 +89,11 @@ diesel::table! {
         specimens -> Integer,
         other -> Integer,
         total_genomic -> Integer,
+        complete_genomes -> Integer,
+        partial_genomes -> Integer,
+        assembly_chromosomes -> Integer,
+        assembly_scaffolds -> Integer,
+        assembly_contigs -> Integer,
     }
 }
 
@@ -138,12 +143,26 @@ diesel::table! {
     taxa_tree_stats (taxon_id, id) {
         taxon_id -> Uuid,
         id -> Uuid,
+        tree_depth -> Integer,
+        children -> BigInt,
+        descendants -> BigInt,
         loci -> Nullable<Numeric>,
         genomes -> Nullable<Numeric>,
         specimens -> Nullable<Numeric>,
         other -> Nullable<Numeric>,
         total_genomic -> Nullable<Numeric>,
         species -> Nullable<BigInt>,
+        complete_genomes -> Nullable<Numeric>,
+        partial_genomes -> Nullable<Numeric>,
+        assembly_chromosomes -> Nullable<Numeric>,
+        assembly_scaffolds -> Nullable<Numeric>,
+        assembly_contigs -> Nullable<Numeric>,
+
+        complete_genomes_coverage -> BigInt,
+        partial_genomes_coverage -> BigInt,
+        assembly_chromosomes_coverage -> BigInt,
+        assembly_scaffolds_coverage -> BigInt,
+        assembly_contigs_coverage -> BigInt,
     }
 }
 

--- a/server/src/database/stats.rs
+++ b/server/src/database/stats.rs
@@ -42,6 +42,18 @@ struct TaxonStat {
     pub other: Option<BigDecimal>,
     pub total_genomic: Option<BigDecimal>,
     pub species: Option<i64>,
+
+    pub complete_genomes: Option<BigDecimal>,
+    pub partial_genomes: Option<BigDecimal>,
+    pub assembly_chromosomes: Option<BigDecimal>,
+    pub assembly_scaffolds: Option<BigDecimal>,
+    pub assembly_contigs: Option<BigDecimal>,
+
+    pub complete_genomes_coverage: i64,
+    pub partial_genomes_coverage: i64,
+    pub assembly_chromosomes_coverage: i64,
+    pub assembly_scaffolds_coverage: i64,
+    pub assembly_contigs_coverage: i64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Queryable, Default)]
@@ -56,6 +68,18 @@ pub struct TaxonStatNode {
     pub other: Option<BigDecimal>,
     pub total_genomic: Option<BigDecimal>,
     pub species: Option<i64>,
+
+    pub complete_genomes: Option<BigDecimal>,
+    pub partial_genomes: Option<BigDecimal>,
+    pub assembly_chromosomes: Option<BigDecimal>,
+    pub assembly_scaffolds: Option<BigDecimal>,
+    pub assembly_contigs: Option<BigDecimal>,
+
+    pub complete_genomes_coverage: i64,
+    pub partial_genomes_coverage: i64,
+    pub assembly_chromosomes_coverage: i64,
+    pub assembly_scaffolds_coverage: i64,
+    pub assembly_contigs_coverage: i64,
 
     pub children: HashMap<String, TaxonStatNode>,
 }
@@ -153,6 +177,16 @@ impl StatsProvider {
                 taxa_tree_stats::other,
                 taxa_tree_stats::total_genomic,
                 taxa_tree_stats::species,
+                taxa_tree_stats::complete_genomes,
+                taxa_tree_stats::partial_genomes,
+                taxa_tree_stats::assembly_chromosomes,
+                taxa_tree_stats::assembly_scaffolds,
+                taxa_tree_stats::assembly_contigs,
+                taxa_tree_stats::complete_genomes_coverage,
+                taxa_tree_stats::partial_genomes_coverage,
+                taxa_tree_stats::assembly_chromosomes_coverage,
+                taxa_tree_stats::assembly_scaffolds_coverage,
+                taxa_tree_stats::assembly_contigs_coverage,
             ))
             // we only wants paths generated from a specific root node otherwise
             // we'd get the same taxon from paths with different roots since the taxa
@@ -224,6 +258,16 @@ impl From<TaxonStat> for TaxonStatNode {
             other: value.other,
             total_genomic: value.total_genomic,
             species: value.species,
+            complete_genomes: value.complete_genomes,
+            partial_genomes: value.partial_genomes,
+            assembly_chromosomes: value.assembly_chromosomes,
+            assembly_scaffolds: value.assembly_scaffolds,
+            assembly_contigs: value.assembly_contigs,
+            complete_genomes_coverage: value.complete_genomes_coverage,
+            partial_genomes_coverage: value.partial_genomes_coverage,
+            assembly_chromosomes_coverage: value.assembly_chromosomes_coverage,
+            assembly_scaffolds_coverage: value.assembly_scaffolds_coverage,
+            assembly_contigs_coverage: value.assembly_contigs_coverage,
             children: HashMap::new(),
         }
     }

--- a/server/src/http/graphql/stats.rs
+++ b/server/src/http/graphql/stats.rs
@@ -127,6 +127,17 @@ pub struct TaxonTreeNodeStatistics {
     /// The total amount of species belonging to the taxon
     pub species: Option<u64>,
 
+    /// The total amount of complete genomes for all species under this taxon
+    pub complete_genomes: Option<u64>,
+    /// The total amount of partial genomes for all species under this taxon
+    pub partial_genomes: Option<u64>,
+    /// The total amount of chromosomes for all species under this taxon
+    pub assembly_chromosomes: Option<u64>,
+    /// The total amount of scaffolds for all species under this taxon
+    pub assembly_scaffolds: Option<u64>,
+    /// The total amount of contigs for all species under this taxon
+    pub assembly_contigs: Option<u64>,
+
     /// The taxa that fall below this taxon rank
     pub children: Vec<TaxonTreeNodeStatistics>,
 }
@@ -164,6 +175,11 @@ impl From<TaxonStatNode> for TaxonTreeNodeStatistics {
             other: value.other.map(|v| v.to_u64().unwrap_or_default()),
             total_genomic: value.total_genomic.map(|v| v.to_u64().unwrap_or_default()),
             species: value.species.map(|v| v as u64),
+            complete_genomes: value.complete_genomes.map(|v| v.to_u64().unwrap_or_default()),
+            partial_genomes: value.partial_genomes.map(|v| v.to_u64().unwrap_or_default()),
+            assembly_chromosomes: value.assembly_chromosomes.map(|v| v.to_u64().unwrap_or_default()),
+            assembly_scaffolds: value.assembly_scaffolds.map(|v| v.to_u64().unwrap_or_default()),
+            assembly_contigs: value.assembly_contigs.map(|v| v.to_u64().unwrap_or_default()),
             children,
         }
     }


### PR DESCRIPTION
example query:

``` graphql
fragment TreeNode on TaxonTreeNodeStatistics {
      scientificName
      canonicalName
      rank
      loci
      genomes
      specimens
      other
      totalGenomic
  		species
  		completeGenomes,
  		partialGenomes,
  		assemblyChromosomes,
  		assemblyScaffolds,
  		assemblyContigs
}

{

  stats {
    taxonBreakdown(taxonRank: "FAMILY", taxonCanonicalName:"Proteaceae", includeRanks:["FAMILY", "GENUS","SPECIES"]) {
			...TreeNode
      children {
        ...TreeNode
        children {
          ...TreeNode
          children{
            ...TreeNode
          }
        }
      }
		}
  }
}
```